### PR TITLE
CMakeLists: Tell GCC/Clang to build in C++14 mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # Set some things up for GCC/Clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-    add_compile_options(-std=c++11)
+    add_compile_options(-std=c++1y)
     if(WARN_MORE)
         add_compile_options(-pedantic -Wall)
         if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")


### PR DESCRIPTION
NLS is now using C++14 features. C++14 mode must be explicitly enabled
in GCC/Clang.
